### PR TITLE
Fix missing closing tag for party-info div

### DIFF
--- a/index.html
+++ b/index.html
@@ -394,6 +394,7 @@
             </div>
           </div>
         </div>
+      </div> <!-- end of party-info -->
       </form>
       <div id='status' class='reveal'></div>
     </div>


### PR DESCRIPTION
## Summary
- close the `party-info` div so it renders correctly after form submission

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68457a8f25908330a30c8d913bb294f5